### PR TITLE
Moving counters

### DIFF
--- a/DeathCounter/DeathCounter.csproj
+++ b/DeathCounter/DeathCounter.csproj
@@ -84,6 +84,7 @@
     <Compile Include="DeathCounter.cs" />
     <Compile Include="Extensions\FsmUtil.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="GlobalSettings.cs" />
     <Compile Include="SaveSettings.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DeathCounter/GlobalSettings.cs
+++ b/DeathCounter/GlobalSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace DeathCounter
+{
+    public class GlobalSettings
+    {
+        public bool ShowCounters = true;
+
+        public bool BesideGeoCount = true;
+
+        public bool UnderGeoCount = false;
+    }
+}


### PR DESCRIPTION
Added new position option under the geo count (so it does not overlap when geo spending tracker is running)
Added menu for choosing position options and moved show/hide toggle here (hits and deaths are still counted in the background)
Added UIClosePauseMenu to update position of counters on closing pause menu
Added NewGameHook to load counters on creation of new game
Added safety for when hiding the counters to prevent unnecessary errors
Cleaned up a few things